### PR TITLE
Update RecipeVisitor.java

### DIFF
--- a/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
+++ b/wrangler-core/src/main/java/io/cdap/wrangler/parser/RecipeVisitor.java
@@ -352,6 +352,18 @@ public Object visitByteSizeArg(DirectivesParser.ByteSizeArgContext ctx) {
     }
 }
 
+  @Override
+public Object visitTimeDurationArg(DirectivesParser.TimeDurationArgContext ctx) {
+    String raw = ctx.getText(); // e.g., "500ms"
+    try {
+        TimeDuration duration = new TimeDuration(raw); // parses and returns canonical value
+        return duration; // or wrap in a Token: new Token(TokenType.TIME_DURATION, duration)
+    } catch (Exception e) {
+        throw new DirectiveParseException("Invalid time duration: " + raw, e);
+    }
+}
+
+
 
   private SourceInfo getOriginalSource(ParserRuleContext ctx) {
     int a = ctx.getStart().getStartIndex();


### PR DESCRIPTION
⏱️ **Added `visitTimeDurationArg()` in `RecipeVisitor.java`** – Parses TIME_DURATION tokens via `TimeDuration.java`, supporting values like "500ms", "2s" for directive arguments.